### PR TITLE
Added activeTab property to EqTabData class

### DIFF
--- a/lib/src/components/tabs/tab.dart
+++ b/lib/src/components/tabs/tab.dart
@@ -9,6 +9,9 @@ class EqTabData {
   /// Leading widget to display alongside [title].
   final WidgetBuilder icon;
 
+  /// Leading widget to display alongside [title] while tab is active.
+  final WidgetBuilder activeIcon;
+
   /// Label to display. Can be null.
   final WidgetBuilder title;
 
@@ -17,6 +20,7 @@ class EqTabData {
 
   EqTabData({
     this.icon,
+    this.activeIcon,
     this.title,
     this.disabled = false,
   });
@@ -24,10 +28,14 @@ class EqTabData {
   factory EqTabData.fromIcon(
       {String title,
       IconData icon,
+      IconData activeIcon,
       bool disabled = false,
       double iconSize = 18.0}) {
     return EqTabData(
       icon: (icon != null) ? (_) => EqIcon(icon, size: iconSize) : null,
+      activeIcon: (icon != null && activeIcon != null)
+          ? (_) => EqIcon(activeIcon, size: iconSize)
+          : null,
       title: (title != null) ? (_) => Text(title) : null,
       disabled: disabled,
     );
@@ -112,7 +120,11 @@ class _EqTabState extends State<EqTab> {
                     mainAxisSize: MainAxisSize.min,
                     mainAxisAlignment: MainAxisAlignment.center,
                     children: [
-                      if (widget.data.icon != null) widget.data.icon(context),
+                      if ((!widget.active && widget.data.icon != null) ||
+                          (widget.active && widget.data.activeIcon == null))
+                        widget.data.icon(context),
+                      if (widget.active && widget.data.activeIcon != null)
+                        widget.data.activeIcon(context),
                       if (widget.data.icon != null && widget.data.title != null)
                         SizedBox(height: 2.0),
                       if (widget.data.title != null) widget.data.title(context),


### PR DESCRIPTION
I don't know if that's in the spirit of the Eva Design, but I added this because I found it very cool.
You can now specify an ```activeIcon``` that is only displayed if the tab is active.

#### Example:
```dart
EqTabData.fromIcon(
  icon: EvaIcons.homeOutline,
  activeIcon: EvaIcons.home,
  title: 'Home',
);
```

#### Result:
![Screenshot 2019-08-04 at 17 33 12](https://user-images.githubusercontent.com/45240351/62425834-11d9eb80-b6de-11e9-80e8-be101b55e911.png) ![Screenshot 2019-08-04 at 17 32 59](https://user-images.githubusercontent.com/45240351/62425841-1b635380-b6de-11e9-8f1f-61aeb9a2173d.png)

#### Notes:
- If no ```activeIcon``` is specified, ```icon``` will be displayed instead if the tab is active.
- ```activeIcon``` is only accepted if ```icon``` is also given.